### PR TITLE
Fix failing timestamp queries

### DIFF
--- a/app/views/restaurants.js
+++ b/app/views/restaurants.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const moment = require('moment-range').extendMoment(require('moment'))
+const moment = require('moment')
 const { BadRequestError, NotFoundError, InternalError } = require('restify-errors')
 
 const store = require('../../data/store')
@@ -33,12 +33,12 @@ exports.open = async (req, res, next) => {
 
     try {
         const regular = `SELECT r.name FROM restaurants r, json_each(r.timings) dt WHERE dt.key = '${d.format('ddd')}' AND ` +
-                        `(json_extract(r.timings, '$.' || dt.key || '[0].start') < '${d.toISOString()}' AND ` +
-                         `json_extract(r.timings, '$.' || dt.key || '[0].end') > '${d.toISOString()}')`
+                        `(json_extract(r.timings, '$.' || dt.key || '[0].start') < '${d.format('hh:mm A')}' AND ` +
+                         `json_extract(r.timings, '$.' || dt.key || '[0].end') > '${d.format('hh:mm A')}')`
 
         const overnight = `SELECT r.name FROM restaurants r, json_each(r.timings) dt WHERE dt.key = '${d.format('ddd')}' AND ` +
-                          `(json_extract(r.timings, '$.' || dt.key || '[1].start') < '${d.toISOString()}' AND ` +
-                           `json_extract(r.timings, '$.' || dt.key || '[1].end') > '${ d.toISOString()}')`
+                          `(json_extract(r.timings, '$.' || dt.key || '[1].start') < '${d.format('hh:mm A')}' AND ` +
+                           `json_extract(r.timings, '$.' || dt.key || '[1].end') > '${ d.format('hh:mm A')}')`
 
         const [rows, metadata] = await store.connection().query(`${regular} UNION ${overnight};`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "config": "^3.3.8",
         "moment": "^2.29.4",
-        "moment-range": "^4.0.2",
         "restify": "^8.6.1",
         "restify-errors": "^8.0.2",
         "restify-router": "^0.6.2",
@@ -2180,15 +2179,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2387,39 +2377,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -2524,19 +2481,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "dependencies": {
-        "type": "^2.5.0"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -4390,20 +4334,6 @@
         "node": "*"
       }
     },
-    "node_modules/moment-range": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
-      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
-      "dependencies": {
-        "es6-symbol": "^3.1.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "peerDependencies": {
-        "moment": ">= 2"
-      }
-    },
     "node_modules/moment-timezone": {
       "version": "0.5.37",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
@@ -4462,11 +4392,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-addon-api": {
       "version": "4.3.0",
@@ -6199,11 +6124,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -8171,15 +8091,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -8341,35 +8252,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "requires": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -8445,21 +8327,6 @@
         "jest-matcher-utils": "^29.0.2",
         "jest-message-util": "^29.0.2",
         "jest-util": "^29.0.2"
-      }
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "requires": {
-        "type": "^2.5.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-        }
       }
     },
     "extsprintf": {
@@ -9902,14 +9769,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
-    "moment-range": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-4.0.2.tgz",
-      "integrity": "sha512-n8sceWwSTjmz++nFHzeNEUsYtDqjgXgcOBzsHi+BoXQU2FW+eU92LUaK8gqOiSu5PG57Q9sYj1Fz4LRDj4FtKA==",
-      "requires": {
-        "es6-symbol": "^3.1.0"
-      }
-    },
     "moment-timezone": {
       "version": "0.5.37",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
@@ -9956,11 +9815,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-addon-api": {
       "version": "4.3.0",
@@ -11232,11 +11086,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "config": "^3.3.8",
     "moment": "^2.29.4",
-    "moment-range": "^4.0.2",
     "restify": "^8.6.1",
     "restify-errors": "^8.0.2",
     "restify-router": "^0.6.2",

--- a/tests/utils/datetime.js
+++ b/tests/utils/datetime.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const moment = require('moment-range').extendMoment(require('moment'))
+const moment = require('moment')
 
 const datetime = require('../../utils/datetime')
 
@@ -12,10 +12,6 @@ function inspect(string) {
 
         expect(days.length).toBeGreaterThan(0)
         expect(hours.length).toBeGreaterThanOrEqual(1)
-        hours.forEach(t => {
-            expect(moment.isRange(t)).toBeTruthy()
-            expect(t.valueOf()).toBeGreaterThanOrEqual(0)
-        })
     }
 }
 
@@ -31,9 +27,6 @@ describe('Parse a given weekly timetable string', () => {
             for (let dt of Object.values(datetime.parse(string))) {
                 let days = Object.keys(dt)
                 expect(days.includes('Invalid date')).toBeTruthy()
-                Object.values(dt).flat().forEach(t => {
-                    expect(moment.isRange(t) && t.valueOf() >= 0).toBeFalsy()
-                })
             }
         })
     })

--- a/utils/datetime.js
+++ b/utils/datetime.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const moment = require('moment-range').extendMoment(require('moment'))
+const moment = require('moment')
 
 const defaults = {
     dates: { month: 'Jan', year: 1970 }
@@ -41,16 +41,19 @@ const parse = (timings) => {
             dt.set('day', dt.day() + 1)
             days.forEach(d => overflows.push({
                 day: d,
-                hours: moment.range(
-                    dt.clone().startOf('day').set(defaults.dates),
-                    dt.set(defaults.dates)
-                )
+                hours: {
+                    start: dt.clone().startOf('day').set(defaults.dates).format('hh:mm A'),
+                    end: dt.set(defaults.dates).format('hh:mm A')
+                }
             }))
         }
 
         days = days.map(d => Object({
             day: d,
-            hours: moment.range(opening.set('day', d), closing.set('day', d))
+            hours: {
+                start: opening.set('day', d).format('hh:mm A'),
+                end: closing.set('day', d).format('hh:mm A')
+            }
         }))
         days.push(...overflows)
         return objectify(days)


### PR DESCRIPTION
ISO format datetime comparisons were flaky due to harcoded month & day values. Minimizing to `ddd hh:mm A` format seems to fix.